### PR TITLE
fix introduction example of aspectlib.Aspect

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -19,7 +19,7 @@ Example:
 .. code-block:: python
 
     @aspectlib.Aspect
-    def strip_return_value():
+    def strip_return_value(*args, **kwargs):
         result = yield aspectlib.Proceed
         yield aspectlib.Return(result.strip())
 


### PR DESCRIPTION
Today I was reading about this library and decided to take a look. I go ahead to the [introduction](https://python-aspectlib.readthedocs.io/en/latest/introduction.html) to see how to use it. Then I saw the following example:
```python
import aspectlib

@aspectlib.Aspect
def strip_return_value():
    result = yield aspectlib.Proceed
    yield aspectlib.Return(result.strip())

@strip_return_value
def read(name):
    return open(name).read()
```
When I call the `read` function, it throws the following exception:
```
Traceback (most recent call last):
  File "test.aspect.py", line 22, in <module>
    print(read('./test.aspect.py'))
  File "/home/german/env/local/lib/python2.7/site-packages/aspectlib/__init__.py", line 253, in advising_function_wrapper
    advisor = self.advising_function(*args, **kwargs)
TypeError: strip_return_value() takes no arguments (1 given)
```
The error is because a parameter is missing on the strip_return_value. I added `*args, **kwargs` just in case.
My runtime is the following:
* Python 2.7.12 (also happens on 3.5)
* aspectlib 1.4.2