### PR TITLE
Do not access attributes that don't match the method selector regex

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Authors
 =======
 
 * Ionel Cristian Mărieș - https://blog.ionelmc.ro
+* Jonas Maurus - https://github.com/jdelic/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+unreleased (2019-07-19)
+-----------------------
+
+* During weaving, stop reading attributes don't match the method selector.
+
 1.4.2 (2016-05-10)
 ------------------
 

--- a/src/aspectlib/__init__.py
+++ b/src/aspectlib/__init__.py
@@ -542,8 +542,8 @@ def weave_instance(instance, aspect, methods=NORMAL_METHODS, lazy=False, bag=Bro
     fixed_aspect = aspect + [fixup] if isinstance(aspect, (list, tuple)) else [aspect, fixup]
 
     for attr in dir(instance):
-        func = getattr(instance, attr)
         if method_matches(attr):
+            func = getattr(instance, attr)
             if ismethod(func):
                 if hasattr(func, '__func__'):
                     realfunc = func.__func__
@@ -572,8 +572,8 @@ def weave_module(module, aspect, methods=NORMAL_METHODS, lazy=False, bag=BrokenB
              module, aspect, methods, lazy, options)
 
     for attr in dir(module):
-        func = getattr(module, attr)
         if method_matches(attr):
+            func = getattr(module, attr)
             if isroutine(func):
                 entanglement.merge(patch_module_function(module, func, aspect, force_name=attr, **options))
             elif isclass(func):
@@ -615,9 +615,10 @@ def weave_class(klass, aspect, methods=NORMAL_METHODS, subclasses=True, lazy=Fal
         def __init__(self, *args, **kwargs):
             super(SubClass, self).__init__(*args, **kwargs)
             for attr in dir(self):
-                func = getattr(self, attr, None)
-                if method_matches(attr) and attr not in wrappers and isroutine(func):
-                    setattr(self, attr, _checked_apply(aspect, force_bind(func)).__get__(self, SubClass))
+                if method_matches(attr) and attr not in wrappers:
+                    func = getattr(self, attr, None)
+                    if isroutine(func):
+                        setattr(self, attr, _checked_apply(aspect, force_bind(func)).__get__(self, SubClass))
 
         wrappers = {
             '__init__': _checked_apply(aspect, __init__) if method_matches('__init__') else __init__


### PR DESCRIPTION
Only evaluate attributes after we know they match the method selector.

Otherwise properties on objects might trigger even though they're not matched by an aspect. Calling `getattr` is unavoidable for those attributes that do match the method selector, but we can avoid reading unrelated attributes.

Sometimes developers do stupid things when attributes are read, like going to the network to read a remote API to get the value. PyGithub, for example, does that. So the order of these instructions, i.e. when precisely we access attributes to apply aspects can make a huge difference.