### PR TITLE
Fix test for Python 3.9

### DIFF
--- a/src/aspectlib/test.py
+++ b/src/aspectlib/test.py
@@ -29,7 +29,10 @@ except ImportError:
 try:
     from dummy_thread import allocate_lock
 except ImportError:
-    from _dummy_thread import allocate_lock
+    try:
+        from _dummy_thread import allocate_lock
+    except ImportError:
+        from _thread import allocate_lock
 try:
     from collections import OrderedDict
 except ImportError:


### PR DESCRIPTION
Python 3.9 has neither dummy_thread nor _dummy_thread anymore. Using _thread.allocate_lock passes all tests here.